### PR TITLE
Remove system admin right from Salary Certificate

### DIFF
--- a/nxpo_hrms/nxpo_hrms/doctype/salary_certificate/salary_certificate.json
+++ b/nxpo_hrms/nxpo_hrms/doctype/salary_certificate/salary_certificate.json
@@ -201,25 +201,13 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-03 23:06:20.936200",
+ "modified": "2024-10-04 10:07:54.889643",
  "modified_by": "Administrator",
  "module": "NXPO HRMS",
  "name": "Salary Certificate",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
   {
    "create": 1,
    "email": 1,


### PR DESCRIPTION
FYI @Saralrat

After I see from similar doctype, i..e, Salary Slip, no rights for System Admin. So, I think for this sensitive data, it should be the same.